### PR TITLE
Potential fix for code scanning alert no. 31: Uncontrolled data used in path expression

### DIFF
--- a/website/web/__init__.py
+++ b/website/web/__init__.py
@@ -945,8 +945,11 @@ def editlogo(database: int, name: str): # type: ignore
         return render_template('admin.html')
     logo =  namedtuple('logo',['link'])
     logos = []
-    logofolder = os.path.normpath(str(get_homedir()) + '/source/logo/'+dbvalue[int(database)]+'/'+name)
-    if  os.path.exists(logofolder):
+    base_path = os.path.normpath(str(get_homedir()) + '/source/logo/' + dbvalue[int(database)])
+    logofolder = os.path.normpath(os.path.join(base_path, name))
+    if not logofolder.startswith(base_path):
+        raise Exception("Invalid path")
+    if os.path.exists(logofolder):
         listlogo = [f for f in listdir(logofolder) if isfile(join(logofolder, f))]
         for f in listlogo:
             logos.append(logo("/logo/"+dbvalue[int(database)]+"/"+name+"/" +f))


### PR DESCRIPTION
Potential fix for [https://github.com/RansomLook/RansomLook/security/code-scanning/31](https://github.com/RansomLook/RansomLook/security/code-scanning/31)

To fix the problem, we need to validate and sanitize the `name` parameter before using it to construct file paths. We can use the `os.path.normpath` function to normalize the path and ensure it does not contain any path traversal sequences. Additionally, we can check that the resulting path is within the expected base directory.

1. Normalize the `name` parameter using `os.path.normpath`.
2. Ensure the normalized path starts with the expected base directory.
3. Raise an exception or handle the error if the validation fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
