### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled data used in path expression

### DIFF
--- a/website/web/__init__.py
+++ b/website/web/__init__.py
@@ -463,9 +463,12 @@ def market(name: str): # type: ignore[no-untyped-def]
                         group= json.loads(red.get(key)) # type: ignore
                         if not current_user.is_authenticated and 'private' in group and group['private'] is True:
                             return redirect(url_for("home"))
-                        logofolder = os.path.normpath(str(get_homedir()) + '/source/logo/market/'+name)
+                        base_path = os.path.normpath(str(get_homedir()) + '/source/logo/market/')
+                        logofolder = os.path.normpath(os.path.join(base_path, name))
                         logo=[]
-                        if  os.path.exists(logofolder):
+                        if not logofolder.startswith(base_path):
+                            raise Exception("Invalid path")
+                        if os.path.exists(logofolder):
                             listlogo = [f for f in listdir(logofolder) if isfile(join(logofolder, f))]
                             for f in listlogo:
                                 logo.append("/logo/market/"+name+"/" +f)


### PR DESCRIPTION
Potential fix for [https://github.com/RansomLook/RansomLook/security/code-scanning/25](https://github.com/RansomLook/RansomLook/security/code-scanning/25)

To fix the problem, we need to validate and sanitize the `name` parameter before using it to construct file paths. We can use the `os.path.normpath` function to normalize the path and ensure it does not contain any path traversal sequences. Additionally, we can check that the resulting path is within the intended directory.

1. Normalize the `name` parameter using `os.path.normpath`.
2. Construct the full path and ensure it is within the intended directory.
3. Raise an exception or handle the error if the path is not valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
