### PR TITLE
Potential fix for code scanning alert no. 19: Uncontrolled data used in path expression

### DIFF
--- a/website/web/__init__.py
+++ b/website/web/__init__.py
@@ -1121,7 +1121,11 @@ def editpostentry(name: str): # type: ignore
                     flash(f'Error to add post to : {name} - Screen should be a PNG', 'error')
                     return render_template('editpost.html', form=form)
                 filenamepng = createfile(post['post_title']) + file_ext
-                path = os.path.normpath(str(get_homedir()) +  '/source/screenshots/' + name)
+                base_path = os.path.normpath(str(get_homedir()) + '/source/screenshots')
+                path = os.path.normpath(os.path.join(base_path, name))
+                if not path.startswith(base_path):
+                    flash(f'Invalid path: {name}', 'error')
+                    return render_template('editpost.html', form=form)
                 if not os.path.exists(path):
                     os.mkdir(path)
                 namepng = os.path.normpath(path +'/' +filenamepng)


### PR DESCRIPTION
Potential fix for [https://github.com/RansomLook/RansomLook/security/code-scanning/19](https://github.com/RansomLook/RansomLook/security/code-scanning/19)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. We can achieve this by normalizing the path and checking that it starts with the intended base directory. This will prevent directory traversal attacks and ensure that the path is safe to use.

1. Normalize the constructed path using `os.path.normpath`.
2. Check that the normalized path starts with the base directory returned by `get_homedir()`.
3. Raise an exception or handle the error if the path is not within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
