### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/website/web/__init__.py
+++ b/website/web/__init__.py
@@ -407,9 +407,12 @@ def group(name: str): # type: ignore[no-untyped-def]
                         group= json.loads(red.get(key)) # type: ignore
                         if not current_user.is_authenticated and 'private' in group and group['private'] is True:
                             return redirect(url_for("home"))
-                        logofolder = os.path.normpath(str(get_homedir()) + '/source/logo/group/'+name)
+                        base_path = os.path.normpath(str(get_homedir()) + '/source/logo/group/')
+                        logofolder = os.path.normpath(os.path.join(base_path, name))
                         logo=[]
-                        if  os.path.exists(logofolder):
+                        if not logofolder.startswith(base_path):
+                            raise Exception("Invalid path")
+                        if os.path.exists(logofolder):
                             listlogo = [f for f in listdir(logofolder) if isfile(join(logofolder, f))]
                             for f in listlogo:
                                 logo.append("/logo/group/"+name+"/" +f)


### PR DESCRIPTION
Potential fix for [https://github.com/RansomLook/RansomLook/security/code-scanning/22](https://github.com/RansomLook/RansomLook/security/code-scanning/22)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the intended base directory. This will prevent path traversal attacks by ensuring that the constructed path does not escape the intended directory.

1. Normalize the constructed path using `os.path.normpath`.
2. Check that the normalized path starts with the intended base directory.
3. Raise an exception or handle the error if the path is not within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
