### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled data used in path expression

### DIFF
--- a/website/web/__init__.py
+++ b/website/web/__init__.py
@@ -1041,10 +1041,13 @@ def addpostentry(database: int, name: str): # type: ignore
                 flash(f'Error to add post to : {name} - Screen should be a PNG', 'error')
                 return render_template('addpostentry.html', form=form)
             filenamepng = createfile(form.title.data) + file_ext
-            path = os.path.normpath(str(get_homedir()) +  '/source/screenshots/' + name)
+            base_path = os.path.normpath(str(get_homedir()) + '/source/screenshots')
+            path = os.path.normpath(os.path.join(base_path, name))
+            if not path.startswith(base_path):
+                raise Exception("Invalid path")
             if not os.path.exists(path):
                 os.mkdir(path)
-            namepng = os.path.normpath(path +'/' +filenamepng)
+            namepng = os.path.normpath(os.path.join(path, filenamepng))
             uploaded_file.save(namepng)
             entry['screen'] = str(os.path.join('screenshots', name, filenamepng))
         if appender(entry, name):


### PR DESCRIPTION
Potential fix for [https://github.com/RansomLook/RansomLook/security/code-scanning/16](https://github.com/RansomLook/RansomLook/security/code-scanning/16)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. This will prevent any directory traversal attacks.

1. Normalize the path using `os.path.normpath`.
2. Check that the normalized path starts with the root folder.
3. Raise an exception if the path is not within the root folder.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
