### PR TITLE
Update Swagger Python examples to omit Authorization header for public endpoints

### DIFF
--- a/website/web/templates/swagger.html
+++ b/website/web/templates/swagger.html
@@ -199,9 +199,8 @@
 <pre><code class="language-python">import requests
 
 API = "https://www.ransomlook.io/api"
-HEADERS = {"Authorization": "YOUR_API_KEY"}
 
-resp = requests.get(f"{API}/posts", params={"days": 7}, headers=HEADERS)
+resp = requests.get(f"{API}/posts", params={"days": 7})
 for post in resp.json():
     print(post["group_name"], "—", post["post_title"])
 </code></pre>
@@ -212,9 +211,8 @@ for post in resp.json():
 <pre><code class="language-python">import requests
 
 API = "https://www.ransomlook.io/api"
-HEADERS = {"Authorization": "YOUR_API_KEY"}
 
-resp = requests.get(f"{API}/group/lockbit", headers=HEADERS)
+resp = requests.get(f"{API}/group/lockbit")
 group = resp.json()
 print(f"Group: {group[0]['name']}")
 for loc in group[0].get("locations", []):
@@ -228,13 +226,13 @@ for loc in group[0].get("locations", []):
 <pre><code class="language-python">import requests
 
 API = "https://www.ransomlook.io/api"
-HEADERS = {"Authorization": "YOUR_API_KEY"}
 
-resp = requests.get(f"{API}/search", params={"query": "acme"}, headers=HEADERS)
+resp = requests.get(f"{API}/search", params={"query": "acme"})
 for hit in resp.json():
     print(hit["group_name"], "—", hit["post_title"], "—", hit["discovered"])
 </code></pre>
       </div>
+
 
       <div class="rl-example">
         <h4>{{ _('Export full database (requires API key)') }}</h4>
@@ -259,9 +257,8 @@ for db_num in [0, 2, 3, 5]:
 <pre><code class="language-python">import requests
 
 API = "https://www.ransomlook.io/api"
-HEADERS = {"Authorization": "YOUR_API_KEY"}
 
-resp = requests.get(f"{API}/actor/bassterlord", headers=HEADERS)
+resp = requests.get(f"{API}/actor/bassterlord")
 actor = resp.json()
 print(f"Actor: {actor.get('name')}")
 print(f"Aliases: {', '.join(actor.get('aliases', []))}")
@@ -275,9 +272,8 @@ for g in actor.get("relations", {}).get("groups", []):
 <pre><code class="language-python">import requests
 
 API = "https://www.ransomlook.io/api"
-HEADERS = {"Authorization": "YOUR_API_KEY"}
 
-resp = requests.get(f"{API}/crypto/lockbit", headers=HEADERS)
+resp = requests.get(f"{API}/crypto/lockbit")
 data = resp.json()
 for chain, addrs in data.get("by_chain", {}).items():
     for a in addrs:


### PR DESCRIPTION
### Motivation
- Remove unnecessary `Authorization` header from public Python examples so they reflect the current API behavior and avoid implying an API key is required for publicly accessible endpoints.

### Description
- Removed `HEADERS = {"Authorization": "YOUR_API_KEY"}` and `headers=HEADERS` from the Python examples for `GET /posts`, `GET /group/<slug>`, `GET /search`, `GET /actor/<slug>`, and `GET /crypto/<group>` while leaving the export example (which requires an API key) unchanged.

### Testing
- No automated tests were added for this template change and the existing CI/test suite was run and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f81d73d04832491822819b42d0562)