### PR TITLE
Add post_title to posts API response

### DIFF
--- a/website/web/api/genericapi.py
+++ b/website/web/api/genericapi.py
@@ -100,6 +100,7 @@ posts_stat_model = api.model(
     "PostStat",
     {
         "group_name": fields.String(description="Group name"),
+        "post_title": fields.String(description="Title of the post"),
         "discovered": fields.String(description="ISO 8601 UTC timestamp (Z suffix)"),
     },
 )
@@ -513,6 +514,7 @@ class Posts(Resource):  # type: ignore[misc]
                     out.append(
                         {
                             "group_name": group_name,
+                            "post_title": p.get("post_title", ""),
                             "discovered": dt.isoformat().replace("+00:00", "Z"),  # propre ISO en Z
                         }
                     )


### PR DESCRIPTION
### Motivation
- Include the post title in the `/api/posts` response to make the payload useful for charting/statistics and to document it in the Swagger model.

### Description
- Update `website/web/api/genericapi.py` to add `post_title` to the `PostStat` Swagger model and include `"post_title": p.get("post_title", "")` in each object returned by the `/api/posts` endpoint.

### Testing
- Ran `python -m compileall website/web/api/genericapi.py` which succeeded, ran `git diff --check`, and ran `ruff check website/web/api/genericapi.py` which reported pre-existing SIM lint issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f84d6f4a08324ac57783c01db5ac5)