### PR TITLE
Potential fix for code scanning alert no. 44: Uncontrolled data used in path expression

### DIFF
--- a/website/web/__init__.py
+++ b/website/web/__init__.py
@@ -2257,7 +2257,10 @@ def admin_group_analyses(name: str):  # type: ignore[no-untyped-def]
         base = _analysis_dir(name)
         if not base:
             abort(400)
-        variant_dir = os.path.join(base, new_id)
+        base_abs = os.path.abspath(base)
+        variant_dir = os.path.abspath(os.path.join(base_abs, new_id))
+        if os.path.commonpath([base_abs, variant_dir]) != base_abs:
+            abort(400)
         os.makedirs(variant_dir, exist_ok=True)
         md = os.path.join(variant_dir, "FULL_ANALYSIS.md")
         if not os.path.isfile(md):


### PR DESCRIPTION
Potential fix for [https://github.com/RansomLook/RansomLook/security/code-scanning/44](https://github.com/RansomLook/RansomLook/security/code-scanning/44)

Use path containment validation after joining paths derived from user input.  
Specifically in `website/web/__init__.py` around `admin_group_analyses` (lines ~2257–2264), compute absolute normalized paths for both `base` and `variant_dir`, then ensure `variant_dir` is inside `base` with `os.path.commonpath`. Abort if not.

Best minimal fix without changing behavior:
- Keep existing `_is_valid_variant` check.
- After `base = _analysis_dir(name)`, compute:
  - `base_abs = os.path.abspath(base)`
  - `variant_dir = os.path.abspath(os.path.join(base_abs, new_id))`
- Reject if `os.path.commonpath([base_abs, variant_dir]) != base_abs`.
- Build `md` from validated `variant_dir` as before.

No new imports or dependencies are needed (module `os` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
